### PR TITLE
Update number of total tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ There are two components to scoring: automated scoring, and judge scoring.
 There are two components to the automated scoring: the test suite, and
 [rubocop][1].
 
-  * The test suite contains 51 tests, which contain **114 assertions**. For
+  * The test suite contains 50 tests, which contain **114 assertions**. For
     every assertion that passes, you will receive 1 point (for a maximum of 114
     points). **NOTE**: you only get points for the tests that come with this
     repository. You're free to add more tests as you develop at your


### PR DESCRIPTION
It looks like there are only 50 tests in the app, not 51, but still 114 assertions. Maybe this is related to the removal of the emergencies_full_response_percentage_test?